### PR TITLE
Update to 1.7.0, pypi.org instead of pypi.io

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.7.0" %}
 
 package:
   name: google-cloud-storage
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: google-cloud-storage-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/g/google-cloud-storage/google-cloud-storage-{{ version }}.tar.gz
-  sha256: 939266b7d5c6df6d45a1aee2c47a09313f813e87790335f00c57708b49480054
+  url: https://pypi.org/packages/source/g/google-cloud-storage/google-cloud-storage-{{ version }}.tar.gz
+  sha256: 16288a2117479acf95f66b59363e9e1b6a53cb2659b1c3bdf21fe15c256c8c05
 
 build:
   number: 0


### PR DESCRIPTION
Doesn't seem like there are any new requirements for this version.